### PR TITLE
fix: raise correct exception for invalid login

### DIFF
--- a/custom_components/watts_vision/watts_api.py
+++ b/custom_components/watts_vision/watts_api.py
@@ -61,7 +61,7 @@ class WattsApi:
                     request_token_result.status_code
                 )
             )
-            raise None
+            return None
 
     def loadData(self):
         """load data from api"""


### PR DESCRIPTION
return None instead of raising it (?!?)
to properly raise the InvalidAuth exception and show related error message